### PR TITLE
added support for hidden files in source

### DIFF
--- a/lib/Config.js
+++ b/lib/Config.js
@@ -63,8 +63,17 @@ class Config {
       return;
     }
 
-    let base = Path.dirname(this.path);
+    const base = Path.dirname(this.path);
+    const source = this.source;
+     
     this.source = Path.resolve(Path.join(base, this.source));
+    
+    // If the original source ended in a /. and the path.resolve
+    // removed it we need to add it back. This is required for
+    // rsync to send hidden files
+    if ((/\/\.$/.test(source) || source === '.') && !/\/\.$/.test(this.source)) {
+      this.source += '/.';
+    }
   }
 
   /**


### PR DESCRIPTION
Rsync will not send hidden files unless the source ends in `/.`, but `path.resolves` removes that. So this fix is to add it back if it was removed and should be there